### PR TITLE
Disable reloading only for stateful vars

### DIFF
--- a/src/integrant/repl/state.clj
+++ b/src/integrant/repl/state.clj
@@ -1,0 +1,10 @@
+(ns integrant.repl.state
+  (:require [clojure.tools.namespace.repl :as repl]))
+
+(repl/disable-reload!)
+
+(def config nil)
+
+(def system nil)
+
+(def preparer nil)


### PR DESCRIPTION
I have been getting somewhat erratic errors with this library that I am not able to reproduce easily.
The `integrant.repl/resume` function raised exception due to Ref instances not being resolved.
At the same time `integrant.core/resume` applied to the same system worked without errors.
I suspect that the error arises when the `integrant.core` is reloaded because reloading is disabled for `integrant.repl`. 
What seemed to fix the issue was to move the stateful vars ('system', ...) into a separate namespace and disable reloading only for that namespace.
Unfortunately I don't really know why (or if) it works. 