### PR TITLE
Disable the reloading of integrant.core from tools.namespace.repl

### DIFF
--- a/src/integrant/repl.clj
+++ b/src/integrant/repl.clj
@@ -3,6 +3,8 @@
             [integrant.repl.state :as state]
             [clojure.tools.namespace.repl :as repl]))
 
+(repl/disable-reload! (find-ns 'integrant.core))
+
 (defn set-prep! [prep]
   (alter-var-root #'state/preparer (constantly prep)))
 


### PR DESCRIPTION
When `tools.namespace.repl` reloads integrant.core, any `defmethod`s provided in code that `tools.namespace.repl` does not reload, get lost, thereby breaking the ability of the system to "reset" itself.

This is especially problematic for dependent libraries that provide `init-key` and `halt-key!` methods. e.g. In my open source libraries, I provide `init-key` and `halt-key!` implementations to ease integration into integrant projects -
https://github.com/7theta/via/blob/master/src/via/server/router.clj#L19

Since `integrant.core` is itself a dependent library, it should be safe to disable reloading it.

Without this change I lose the `init-key` methods from `via` and the system does not reset.

Calling `load-namespaces` again does not fix it since the `via` namespaces have not been unloaded and updating `load-namespaces` to use `(require sym :reload)` or `(require sym :reload-all)` runs into https://dev.clojure.org/jira/browse/CLJ-1401