### PR TITLE
Check system exists before attempting to halt it

### DIFF
--- a/src/integrant/repl.clj
+++ b/src/integrant/repl.clj
@@ -23,10 +23,11 @@
   (try
     (build)
     (catch clojure.lang.ExceptionInfo ex
-      (try
-        (ig/halt! (:system (ex-data ex)))
-        (catch clojure.lang.ExceptionInfo halt-ex
-          (throw (wrap-ex ex halt-ex))))
+      (if-let [system (:system (ex-data ex))]
+        (try
+          (ig/halt! system)
+          (catch clojure.lang.ExceptionInfo halt-ex
+            (throw (wrap-ex ex halt-ex)))))
       (throw ex))))
 
 (defn- init-system [config]


### PR DESCRIPTION
If an exception occurs inside `ig/init` then the system map is likely to be `nil`, in which case a `java.lang.AssertionError` is thrown and not caught. Therefore the original exception is not visible.

First check `system` is truthy before trying to halt it.