### PR TITLE
Parameterize `reset`, `reset-all` functions

### DIFF
--- a/src/integrant/repl.clj
+++ b/src/integrant/repl.clj
@@ -79,10 +79,16 @@
       :resumed)
     (throw (prep-error))))
 
-(defn reset []
-  (suspend)
-  (repl/refresh :after 'integrant.repl/resume))
+(defn reset
+  ([]
+   (reset 'integrant.repl/resume))
+  ([after]
+   (suspend)
+   (repl/refresh :after after)))
 
-(defn reset-all []
-  (suspend)
-  (repl/refresh-all :after 'integrant.repl/resume))
+(defn reset-all
+  ([]
+   (reset-all 'integrant.repl/resume))
+  ([after]
+   (suspend)
+   (repl/refresh-all :after after)))


### PR DESCRIPTION
At work we use a dynamic configuration and startup system: our Integrant config comes from a script, and the call to `ig/init` has to be located in a specific place.

Those two in combination make it hard of us to use integrant-repl. By parameterizing the `reset` funcitons, we are able to use our custom setup.

I checked that these changes work as desired: we gained the capability of a `reset` that survives compilation errors.