### PR TITLE
Update dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src"]
- :deps  {org.clojure/clojure         {:mvn/version "1.10.1"}
-         org.clojure/tools.namespace {:mvn/version "1.0.0"}
+ :deps  {org.clojure/clojure         {:mvn/version "1.11.1"}
+         org.clojure/tools.namespace {:mvn/version "1.4.4"}
          integrant/integrant         {:mvn/version "0.8.0"}}}

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "https://github.com/weavejester/integrant-repl"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/tools.namespace "1.0.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.clojure/tools.namespace "1.4.4"]
                  [integrant "0.8.0"]])


### PR DESCRIPTION
With the upgrade of tools.namespace, integrant-repl will support reloading namespaces with `:as-alias` dependency cycles by default.