### PR TITLE
Fix: Clarify README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ For example:
 
 ```clojure
 (ns user
-  (:require [integrant.repl :refer [clear go halt prep init reset reset-all]]))
+  (:require [integrant.core :as ig] 
+            [integrant.repl :refer [clear go halt prep init reset reset-all]]))
 
 (integrant.repl/set-prep! #(ig/prep {::foo {:example? true}}))
 ```


### PR DESCRIPTION
`No such namespace: ig` is the resulting error if you copy / paste the example code into a repl