### PR TITLE
Fix arity of :log-fn passed to clj-reload.core/reload

### DIFF
--- a/src/integrant/repl.clj
+++ b/src/integrant/repl.clj
@@ -106,7 +106,7 @@
     (throw (prep-error))))
 
 (defn- reload [opts]
-  (let [result (reload/reload (assoc opts :log-fn (fn [_])))]
+  (let [result (reload/reload (assoc opts :log-fn (fn [& _])))]
     (prn :reloaded (apply list (:loaded result)))))
 
 (defn reset


### PR DESCRIPTION
Apparently, `reload/reload` would like function that works with any arity, as documented here: https://github.com/tonsky/clj-reload/blob/61c6fa77855efc0b4d052f06c7cc8b2b8817c4aa/src/clj_reload/core.clj#L338

With the single-parameter arity I'm getting an exception from logging that masks my actual problem:
```
Execution error (ArityException) at clj-reload.util/log (util.clj:15).
Wrong number of args (3) passed to: integrant.repl/reload/fn--31852
```